### PR TITLE
[BF-129] Parsing expires data from UTC format

### DIFF
--- a/fortune-cookie.html
+++ b/fortune-cookie.html
@@ -272,7 +272,7 @@ Reload:
     },
 
     _parseExpiresFromUTC: function(timestamp) {
-      return timestamp && new Date(new Date(timestamp).toISOString().substring(0, 23)).getTime();
+      return timestamp && new Date(new Date(timestamp).toUTCString().substring(0, 25)).getTime();
     },
 
     /**

--- a/fortune-cookie.html
+++ b/fortune-cookie.html
@@ -258,18 +258,23 @@ Reload:
     load: function() {
       var kv = this._parseCookie();
       var value = kv && kv.value;
-      
+
       if (!value) {
         this.fire('fortune-cookie-load-empty', this.name);
       }
       else if (value && this.handleValueAs.toLowerCase() === 'object') {
         var object = JSON.parse(value);
-        this.expires = object._expires || object.expires;
+        this.expires = object._expires || this._parseExpiresFromUTC(object.expires);
         this.value = object;
       } else {
         this.value = value.replace(/\"/g, '');
       }
     },
+
+    _parseExpiresFromUTC: function(timestamp) {
+      return timestamp && new Date(new Date(timestamp).toISOString().substring(0, 23)).getTime();
+    },
+
     /**
      * Returns true if the cookie is currently set.
      *


### PR DESCRIPTION
When the value of expires is saved with the value generated from API (`expires` property without underscore) we must parse it.